### PR TITLE
MMI - use key data instead of payload

### DIFF
--- a/src/openrpc.json
+++ b/src/openrpc.json
@@ -212,7 +212,7 @@
               "name": "custodianSignExampleAddressAndPayload",
               "value": {
                 "address": "0xb2c77973279baaaf48c295145802695631d50c01",
-                "payload": "0x48656c6c6f20776f726c64" 
+                "message": "0x48656c6c6f20776f726c64" 
               }
             },
             {

--- a/src/openrpc.json
+++ b/src/openrpc.json
@@ -265,7 +265,7 @@
               "name": "custodianSignTypedDataExampleAddress",
               "value": {
                 "address": "0xb2c77973279baaaf48c295145802695631d50c01",
-                "payload": {
+                "data": {
                   "types": {
                     "EIP712Domain": [
                       {


### PR DESCRIPTION
In signTypedData result.